### PR TITLE
Add github action workflow to provide multiarch image

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -5,7 +5,7 @@ on:
     branches: [ master ]
 
 jobs:
-  build_immage:
+  build_image:
     runs-on: ubuntu-latest
     steps:
       -
@@ -54,7 +54,10 @@ jobs:
           platforms: linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/386
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.prep.outputs.tags }}
-          build-args: CI_COMMIT_BRANCH=${{ steps.prep.outputs.branch }},CI_COMMIT_SHA=${{ github.sha }},CI_PIPELINE_CREATED_AT=${{ steps.prep.outputs.timestamp }}
+          build-args: |
+            CI_COMMIT_BRANCH${{ steps.prep.outputs.branch }}
+            CI_COMMIT_SHA=${{ github.sha }}
+            CI_PIPELINE_CREATED_AT=${{ steps.prep.outputs.timestamp }}
           labels: |
             org.opencontainers.image.title=${{ fromJson(steps.repo.outputs.result).name }}
             org.opencontainers.image.description=${{ fromJson(steps.repo.outputs.result).description }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,66 @@
+name: Build Docker mulitarch image
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  build immage:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Repo metadata
+        id: repo
+        uses: actions/github-script@v3
+        with:
+          script: |
+            const repo = await github.repos.get(context.repo)
+            return repo.data
+      -
+        name: Prepare
+        id: prep
+        run: |
+          DOCKER_IMAGE=${{ github.repository }}
+          VERSION="latest"
+          TAGS="${DOCKER_IMAGE}:${VERSION}"
+          echo ::set-output name=version::${VERSION}
+          echo ::set-output name=tags::${TAGS}
+          echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+          echo ::set-output name=timestamp::$(date +'%s')
+          echo ::set-output name=branch::$(echo ${GITHUB_REF#refs/heads/})
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to DockerHub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      -
+        name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/386
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.prep.outputs.tags }}
+          build-args: CI_COMMIT_BRANCH=${{ steps.prep.outputs.branch }},CI_COMMIT_SHA=${{ github.sha }},CI_PIPELINE_CREATED_AT=${{ steps.prep.outputs.timestamp }}
+          labels: |
+            org.opencontainers.image.title=${{ fromJson(steps.repo.outputs.result).name }}
+            org.opencontainers.image.description=${{ fromJson(steps.repo.outputs.result).description }}
+            org.opencontainers.image.url=${{ fromJson(steps.repo.outputs.result).html_url }}
+            org.opencontainers.image.source=${{ fromJson(steps.repo.outputs.result).clone_url }}
+            org.opencontainers.image.version=${{ steps.prep.outputs.version }}
+            org.opencontainers.image.created=${{ steps.prep.outputs.created }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.licenses=${{ fromJson(steps.repo.outputs.result).license.spdx_id }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -5,7 +5,7 @@ on:
     branches: [ master ]
 
 jobs:
-  build immage:
+  build_immage:
     runs-on: ubuntu-latest
     steps:
       -

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -55,7 +55,7 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.prep.outputs.tags }}
           build-args: |
-            CI_COMMIT_BRANCH${{ steps.prep.outputs.branch }}
+            CI_COMMIT_BRANCH=${{ steps.prep.outputs.branch }}
             CI_COMMIT_SHA=${{ github.sha }}
             CI_PIPELINE_CREATED_AT=${{ steps.prep.outputs.timestamp }}
           labels: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16-alpine as builder
+FROM --platform=$TARGETPLATFORM golang:1.16-alpine as builder
 
 ARG CI_COMMIT_TAG
 ARG CI_COMMIT_BRANCH
@@ -16,7 +16,7 @@ RUN CGO_ENABLED=0 go build -o release/swarm-updater \
    -X main.Commit=${CI_COMMIT_SHA:0:8} \
    -X main.BuildTime=${CI_PIPELINE_CREATED_AT}"
 
-FROM alpine:3.13
+FROM --platform=$TARGETPLATFORM alpine:3.13
 LABEL maintainer="codestation <codestation404@gmail.com>"
 
 RUN apk add --no-cache ca-certificates tzdata


### PR DESCRIPTION
This PR adds github workflow script and modifies Dockerfile in order to build multiarch docker image using github actions. 

In order to push output images to docker hub, personal access token must be created in docker hub and saved in repository's settings->secrets with name DOCKER_PASSWORD along with second secret DOCKER_USERNAME.

It triggers build on any push to master branch and tags it as latest. CI build-args are provided.

fixes #2 